### PR TITLE
Fix perm parser attribute for struct compatibility

### DIFF
--- a/include/boost/parser/parser.hpp
+++ b/include/boost/parser/parser.hpp
@@ -3625,7 +3625,7 @@ namespace boost { namespace parser {
             typename Sentinel,
             typename Context,
             typename SkipParser,
-            typename... Ts,
+            typename Attribute,
             int... Is>
         void call_impl(
             Iter & first,
@@ -3634,10 +3634,10 @@ namespace boost { namespace parser {
             SkipParser const & skip,
             detail::flags flags,
             bool & success,
-            tuple<Ts...> & retval,
+            Attribute & retval,
             std::integer_sequence<int, Is...>) const
         {
-            std::array<bool, sizeof...(Ts)> used_parsers = {{}};
+            std::array<bool, detail::tuple_size_<ParserTuple>> used_parsers = {{}};
 
             // Use "parser" to fill in attribute "x", unless "parser" has
             // previously been used.
@@ -3678,7 +3678,7 @@ namespace boost { namespace parser {
             success = (parsed_one(Is) && ...);
 
             if (!success)
-                retval = tuple<Ts...>{};
+                detail::assign(retval, Attribute());
         }
 
 #ifndef BOOST_PARSER_DOXYGEN

--- a/test/parser_perm.cpp
+++ b/test/parser_perm.cpp
@@ -14,6 +14,9 @@
 namespace bp = boost::parser;
 using namespace std::literals;
 
+namespace
+{
+
 struct data
 {
     int i;
@@ -24,6 +27,8 @@ constexpr bp::rule<struct data_tag, data> data_rule = "data";
 auto data_rule_def =
     (bp::lit("i=") >> bp::int_) || (bp::lit("c=") >> bp::char_);
 BOOST_PARSER_DEFINE_RULES(data_rule);
+
+} // namespace
 
 int main()
 {

--- a/test/parser_perm.cpp
+++ b/test/parser_perm.cpp
@@ -14,6 +14,17 @@
 namespace bp = boost::parser;
 using namespace std::literals;
 
+struct data
+{
+    int i;
+    char c;
+};
+
+constexpr bp::rule<struct data_tag, data> data_rule = "data";
+auto data_rule_def =
+    (bp::lit("i=") >> bp::int_) || (bp::lit("c=") >> bp::char_);
+BOOST_PARSER_DEFINE_RULES(data_rule);
+
 int main()
 {
     {
@@ -38,6 +49,21 @@ int main()
             auto result = bp::parse("foo42", parser, bp::ws);
             BOOST_TEST(result);
             BOOST_TEST(*result == (bp::tuple<int, std::string>(42, "foo"s)));
+        }
+    }
+
+    {
+        {
+            auto result = bp::parse("i=42 c=g", data_rule, bp::ws);
+            BOOST_TEST(result);
+            BOOST_TEST(result->i == 42);
+            BOOST_TEST(result->c == 'g');
+        }
+        {
+            auto result = bp::parse("c=g i=42", data_rule, bp::ws);
+            BOOST_TEST(result);
+            BOOST_TEST(result->i == 42);
+            BOOST_TEST(result->c == 'g');
         }
     }
 


### PR DESCRIPTION
## Summary
- allow permutation parser to store results in non-tuple attributes
- test parsing a struct using permutation operator

## Testing
- `cmake --build build -j 2`
- `cd build && ctest` *(fails: No test configuration file found!)*

------
https://chatgpt.com/codex/tasks/task_e_689ae2f2dcb8832f9998b764b8976719